### PR TITLE
fix(build): externalize echarts peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- Moved `echarts` to a peer dependency and externalized it from the library bundle so
+  host applications can reuse their own ECharts installation.
+
+### Migration Notes
+
+- Install `echarts` alongside the renderer if your app does not already provide a
+  compatible version: `npm install @aiden0z/pptx-renderer echarts`.
+
 ## [1.2.2] - 2026-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,13 +34,16 @@ Every rendering capability is automatically verified against PowerPoint output. 
 ## Install
 
 ```bash
-npm install @aiden0z/pptx-renderer
+npm install @aiden0z/pptx-renderer echarts
 # or
-pnpm add @aiden0z/pptx-renderer
+pnpm add @aiden0z/pptx-renderer echarts
 
 # Optional: only needed for SmartArt / EMF files with embedded PDF fallback previews
 pnpm add pdfjs-dist
 ```
+
+`echarts` is a peer dependency used for PPTX chart rendering. Install it alongside
+the renderer, or reuse the compatible ECharts version already present in your app.
 
 Requires Node.js 20+ for development. Runtime is browser-only.
 

--- a/package.json
+++ b/package.json
@@ -82,10 +82,10 @@
     ]
   },
   "dependencies": {
-    "echarts": "^6.0.0",
     "jszip": "^3.10.1"
   },
   "peerDependencies": {
+    "echarts": "^6.0.0",
     "pdfjs-dist": "^5.0.0"
   },
   "peerDependenciesMeta": {
@@ -100,6 +100,7 @@
     "@size-limit/file": "^12.0.0",
     "@vitest/coverage-v8": "^3.2.4",
     "canvas": "^3.2.1",
+    "echarts": "^6.0.0",
     "eslint": "^10.0.2",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      echarts:
-        specifier: ^6.0.0
-        version: 6.0.0
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -36,6 +33,9 @@ importers:
       canvas:
         specifier: ^3.2.1
         version: 3.2.1
+      echarts:
+        specifier: ^6.0.0
+        version: 6.0.0
       eslint:
         specifier: ^10.0.2
         version: 10.0.2(jiti@2.6.1)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,10 +34,11 @@ export default defineConfig({
             res.end('[]');
             return;
           }
-          const dirs = fs.readdirSync(casesDir, { withFileTypes: true })
-            .filter(d => d.isDirectory())
-            .map(d => d.name)
-            .filter(name => fs.existsSync(resolve(casesDir, name, 'source.pptx')))
+          const dirs = fs
+            .readdirSync(casesDir, { withFileTypes: true })
+            .filter((d) => d.isDirectory())
+            .map((d) => d.name)
+            .filter((name) => fs.existsSync(resolve(casesDir, name, 'source.pptx')))
             .sort();
           res.setHeader('Content-Type', 'application/json');
           res.end(JSON.stringify(dirs));
@@ -49,9 +50,13 @@ export default defineConfig({
           if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
             const ext = filePath.split('.').pop()?.toLowerCase();
             const mimeTypes: Record<string, string> = {
-              png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg',
-              pdf: 'application/pdf', pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-              json: 'application/json', xml: 'text/xml',
+              png: 'image/png',
+              jpg: 'image/jpeg',
+              jpeg: 'image/jpeg',
+              pdf: 'application/pdf',
+              pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+              json: 'application/json',
+              xml: 'text/xml',
             };
             if (ext && mimeTypes[ext]) res.setHeader('Content-Type', mimeTypes[ext]);
             const stream = fs.createReadStream(filePath);
@@ -68,12 +73,17 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'PptxRenderer',
       formats: ['es', 'cjs'],
-      fileName: (format) => format === 'es' ? 'aiden0z-pptx-renderer.es.js' : 'aiden0z-pptx-renderer.cjs',
+      fileName: (format) =>
+        format === 'es' ? 'aiden0z-pptx-renderer.es.js' : 'aiden0z-pptx-renderer.cjs',
     },
     rollupOptions: {
-      external: ['jszip', 'pdfjs-dist'],
+      external: ['echarts', 'jszip', 'pdfjs-dist'],
       output: {
-        globals: { jszip: 'JSZip', 'pdfjs-dist': 'pdfjsLib' },
+        globals: {
+          echarts: 'echarts',
+          jszip: 'JSZip',
+          'pdfjs-dist': 'pdfjsLib',
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

- Move `echarts` from a bundled dependency to a peer dependency.
- Externalize `echarts` from the library build so host applications can reuse their existing ECharts installation.
- Document the install/migration requirement in README and CHANGELOG.

## Scope

- [x] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Refactor
- [ ] Performance
- [ ] Security

## Verification

- [ ] `pnpm test`
- [x] `pnpm build`
- [x] Manual check (if applicable)

Commands and key outputs:

```bash
CI=true pnpm lint
# eslint src/ passed

CI=true pnpm format:check
# All matched files use Prettier code style!

CI=true pnpm typecheck
# tsc --noEmit passed

CI=true pnpm build
# dist/aiden0z-pptx-renderer.es.js  507.65 kB | gzip: 123.18 kB
# dist/aiden0z-pptx-renderer.cjs    373.09 kB | gzip: 107.28 kB

CI=true pnpm size
# Size limit: 1.4 MB
# Size:       122.45 kB gzipped

CI=true pnpm publint
# All good!
```

`pnpm test` was not run locally; this PR is covered by package/build checks and CI can run the full unit suite.

## Compatibility / Risk

- Breaking changes: consumers that do not already install `echarts` now need to install it explicitly alongside `@aiden0z/pptx-renderer`.
- Risk areas: package installation and bundler resolution for chart rendering.

## Security Impact

- [x] No security impact
- [ ] Security relevant (describe threat/mitigation)

## Docs

- [x] README updated
- [ ] docs/* updated
- [ ] No doc updates needed

## Release Notes

- [x] Changelog updated
- [ ] Not user-facing change
