### PR TITLE
fix: improve PowerPoint text layout fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Preserved consecutive blank text paragraphs, used DrawingML's inscribed text rectangle for
+  rounded rectangles, and kept both OOXML percentage encodings unitless across mixed run sizes
+  and `normAutofit` reductions.
 - Sized tables from their column/row grid (Σ column widths × Σ row heights) instead of the
   graphicFrame `<a:ext>`, so tables authored in Google Slides — which export a stale
   placeholder ext — no longer render squished with clipped cell text.

--- a/src/parser/units.ts
+++ b/src/parser/units.ts
@@ -29,6 +29,16 @@ export function pctToDecimal(pct: number): number {
   return pct / 100000;
 }
 
+/** OOXML percentage in either integer-thousandths (`120000`) or percent-string (`120%`) form. */
+export function parseOoxmlPercent(value: string | undefined): number | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  const isPercentString = trimmed.endsWith('%');
+  const parsed = Number(isPercentString ? trimmed.slice(0, -1) : trimmed);
+  if (!Number.isFinite(parsed)) return undefined;
+  return parsed / (isPercentString ? 100 : 100000);
+}
+
 /** Hundredths of a point to points (used for font sizes in OOXML). */
 export function hundredthPtToPt(val: number): number {
   return val / 100;

--- a/src/renderer/ShapeRenderer.ts
+++ b/src/renderer/ShapeRenderer.ts
@@ -2436,6 +2436,13 @@ export function renderShape(node: ShapeNodeData, ctx: RenderContext): HTMLElemen
         textContainer.style.top = `${node.textBoxBounds.y}px`;
         textContainer.style.width = `${node.textBoxBounds.w}px`;
         textContainer.style.height = `${node.textBoxBounds.h}px`;
+      } else if (node.presetGeometry === 'roundRect') {
+        const adjustment = Math.min(Math.max(node.adjustments.get('adj') ?? 16667, 0), 50000);
+        const inset = Math.min(node.size.w, node.size.h) * (adjustment / 100000) * 0.29289;
+        textContainer.style.left = `${inset}px`;
+        textContainer.style.top = `${inset}px`;
+        textContainer.style.width = `${node.size.w - 2 * inset}px`;
+        textContainer.style.height = `${node.size.h - 2 * inset}px`;
       } else {
         textContainer.style.left = '0';
         textContainer.style.top = '0';
@@ -2492,14 +2499,9 @@ export function renderShape(node: ShapeNodeData, ctx: RenderContext): HTMLElemen
       if (hasNormAutofit && normAutofit) {
         textContainer.style.overflowX = 'hidden';
         textContainer.style.overflowY = 'hidden';
-        const lnSpcReduction = normAutofit.numAttr('lnSpcReduction') ?? 0;
         // renderTextBody applies normAutofit@fontScale to run and paragraph font sizes.
         // The container transform is reserved for additional browser-measured shrink.
         needsDynamicAutofit = true;
-        if (lnSpcReduction > 0) {
-          const lnFactor = 1 - lnSpcReduction / 100000;
-          textContainer.style.lineHeight = `${lnFactor}`;
-        }
       }
       // spAutoFit requests in-shape text fitting. In browser rendering we cannot
       // resize the absolutely positioned shape like PowerPoint editor behavior,

--- a/src/renderer/TextRenderer.ts
+++ b/src/renderer/TextRenderer.ts
@@ -1071,13 +1071,10 @@ export function renderTextBody(
       // Bullet color: explicit buClr > first visible run text color > inherited defaults > fallback.
       let bulletColor: string | undefined;
       const firstVisibleRunTextColor = (): string | undefined => {
-        const firstVisibleRun = paragraph.runs.find(
-          (run) => run.text != null && run.text.length > 0,
-        );
-        if (!firstVisibleRun) return undefined;
+        if (!firstVisibleTextRun) return undefined;
         const runStyle = getParagraphDefaultRunStyle(merged, ctx);
-        if (firstVisibleRun.properties) {
-          mergeRunProps(runStyle, firstVisibleRun.properties, ctx);
+        if (firstVisibleTextRun.properties) {
+          mergeRunProps(runStyle, firstVisibleTextRun.properties, ctx);
         }
         return (
           runStyle.color ??
@@ -1139,16 +1136,12 @@ export function renderTextBody(
     }
 
     for (const [runIndex, run] of paragraph.runs.entries()) {
-      if (run.text === '\n') {
-        if (useLineWrappers) {
-          // Close current line div and start a new one
-          currentLineDiv = document.createElement('div');
-          currentLineDiv.style.height = effectiveLineHeight!;
-          currentLineDiv.style.overflow = 'visible';
-          paraDiv.appendChild(currentLineDiv);
-        } else {
-          paraDiv.appendChild(document.createElement('br'));
-        }
+      if (run.text === '\n' && useLineWrappers) {
+        // Close current line div and start a new one
+        currentLineDiv = document.createElement('div');
+        currentLineDiv.style.height = effectiveLineHeight!;
+        currentLineDiv.style.overflow = 'visible';
+        paraDiv.appendChild(currentLineDiv);
         continue;
       }
 
@@ -1182,7 +1175,9 @@ export function renderTextBody(
 
       // Determine if this should be a link
       let element: HTMLElement;
-      if (runStyle.hlinkSlideIndex !== undefined) {
+      if (run.text === '\n') {
+        element = document.createElement('span');
+      } else if (runStyle.hlinkSlideIndex !== undefined) {
         const span = document.createElement('span');
         const slideIndex = runStyle.hlinkSlideIndex;
         span.setAttribute('role', 'link');
@@ -1226,7 +1221,9 @@ export function renderTextBody(
         !!compactNumericToken &&
         run.text !== compactNumericToken &&
         !usesElementLevelTextPaint;
-      if (run.text && run.text.includes('\t')) {
+      if (run.text === '\n') {
+        element.appendChild(document.createElement('br'));
+      } else if (run.text && run.text.includes('\t')) {
         element.textContent = run.text;
         element.style.whiteSpace = 'pre';
       } else if (shouldSplitCompactNumericToken) {

--- a/src/renderer/TextRenderer.ts
+++ b/src/renderer/TextRenderer.ts
@@ -8,7 +8,7 @@ import { RenderContext } from './RenderContext';
 import type { TextBody, TextParagraph, TextRun } from '../model/nodes/ShapeNode';
 import { PlaceholderInfo } from '../model/nodes/BaseNode';
 import { resolveColor, resolveColorToCss, resolveFill } from './StyleResolver';
-import { emuToPx, pctToDecimal, angleToDeg } from '../parser/units';
+import { emuToPx, pctToDecimal, parseOoxmlPercent, angleToDeg } from '../parser/units';
 import { parseOoxmlBool } from '../parser/booleans';
 import { isExternalTargetMode } from '../parser/RelParser';
 import { isAllowedExternalUrl } from '../utils/urlSafety';
@@ -201,7 +201,7 @@ function mergeParagraphProps(target: MergedParagraphStyle, pPr: SafeXmlNode): vo
   if (defTabSz !== undefined) target.defaultTabSize = emuToPx(defTabSz);
 
   // Line spacing
-  // OOXML spcPct: 100000 = "single spacing" = 1.0× the font's line height.
+  // OOXML spcPct is a percentage of the text size.
   // IMPORTANT: We must use UNITLESS CSS line-height values (e.g., 1.0, 1.2)
   // instead of percentages (e.g., 100%, 120%). CSS percentage line-height is
   // computed once against the element's own font-size and inherited as a FIXED
@@ -213,10 +213,10 @@ function mergeParagraphProps(target: MergedParagraphStyle, pPr: SafeXmlNode): vo
   if (lnSpc.exists()) {
     const spcPct = lnSpc.child('spcPct');
     if (spcPct.exists()) {
-      const val = spcPct.numAttr('val');
+      const val = parseOoxmlPercent(spcPct.attr('val'));
       if (val !== undefined) {
-        // OOXML 100000 → CSS unitless 1.0; OOXML 120000 → CSS 1.2
-        target.lineHeight = `${(val / 100000).toFixed(3)}`;
+        target.lineHeight = `${val.toFixed(3)}`;
+        target.lineHeightAbsolute = false;
       }
     }
     const spcPts = lnSpc.child('spcPts');
@@ -239,8 +239,8 @@ function mergeParagraphProps(target: MergedParagraphStyle, pPr: SafeXmlNode): vo
     }
     const spcPct = spcBef.child('spcPct');
     if (spcPct.exists()) {
-      const val = spcPct.numAttr('val');
-      if (val !== undefined) target.spaceBeforePct = val / 100000; // store as ratio
+      const val = parseOoxmlPercent(spcPct.attr('val'));
+      if (val !== undefined) target.spaceBeforePct = val;
     }
   }
 
@@ -254,8 +254,8 @@ function mergeParagraphProps(target: MergedParagraphStyle, pPr: SafeXmlNode): vo
     }
     const spcPct = spcAft.child('spcPct');
     if (spcPct.exists()) {
-      const val = spcPct.numAttr('val');
-      if (val !== undefined) target.spaceAfterPct = val / 100000; // store as ratio
+      const val = parseOoxmlPercent(spcPct.attr('val'));
+      if (val !== undefined) target.spaceAfterPct = val;
     }
   }
 
@@ -845,10 +845,8 @@ export function renderTextBody(
   let lnSpcReduction = 0;
   const normAutofit = getEffectiveBodyPrChild(textBody, 'normAutofit');
   if (normAutofit?.exists()) {
-    const fs = normAutofit.numAttr('fontScale');
-    if (fs !== undefined) fontScale = fs / 100000; // 100000 = 100%
-    const lsr = normAutofit.numAttr('lnSpcReduction');
-    if (lsr !== undefined) lnSpcReduction = lsr / 100000; // e.g., 20000 = 20%
+    fontScale = parseOoxmlPercent(normAutofit.attr('fontScale')) ?? 1;
+    lnSpcReduction = parseOoxmlPercent(normAutofit.attr('lnSpcReduction')) ?? 0;
   }
 
   const bulletCounters = new Map<string, number>();
@@ -928,6 +926,11 @@ export function renderTextBody(
       mergeParagraphProps(merged, paragraph.properties);
     }
 
+    const hasVisibleRuns = paragraph.runs.some((run) => run.text != null && run.text.length > 0);
+    const firstVisibleTextRun = paragraph.runs.find(
+      (run) => run.text != null && run.text.length > 0 && run.text !== '\n' && run.text !== '\t',
+    );
+
     // ---- Apply paragraph styles ----
     if (merged.align) {
       const alignMap: Record<string, string> = {
@@ -951,16 +954,14 @@ export function renderTextBody(
       paraDiv.style.textIndent = `${merged.textIndent}px`;
     }
     // Compute effective line-height (with optional lnSpcReduction from normAutofit)
+    const hasPercentageLineSpacing =
+      merged.lineHeight !== undefined && merged.lineHeightAbsolute === false;
     let effectiveLineHeight = merged.lineHeight ?? options?.defaultLineHeight;
     if (effectiveLineHeight) {
-      if (lnSpcReduction > 0) {
+      if (lnSpcReduction > 0 && hasPercentageLineSpacing) {
         const parsed = parseFloat(effectiveLineHeight);
         if (!isNaN(parsed)) {
-          if (effectiveLineHeight.includes('pt')) {
-            effectiveLineHeight = `${(parsed * (1 - lnSpcReduction)).toFixed(2)}pt`;
-          } else {
-            effectiveLineHeight = `${(parsed * (1 - lnSpcReduction)).toFixed(3)}`;
-          }
+          effectiveLineHeight = `${(parsed * (1 - lnSpcReduction)).toFixed(3)}`;
         }
       }
       if (options?.isVerticalText && !merged.lineHeightAbsolute) {
@@ -970,22 +971,27 @@ export function renderTextBody(
       }
       paraDiv.style.lineHeight = effectiveLineHeight!;
     }
-    // Determine effective font size for percentage-based spacing
-    // Use defRPr or first run's font size, fallback to 12pt
-    let effectiveFontSize = 12; // default 12pt
+    // Keep the paragraph strut aligned with its first visible run. Blank paragraphs use
+    // line-break properties when present, then fall back to endParaRPr.
     const defaultRunStyle = getParagraphDefaultRunStyle(merged, ctx);
-    if (defaultRunStyle.fontSize !== undefined) effectiveFontSize = defaultRunStyle.fontSize;
-    if (paragraph.runs.length > 0 && paragraph.runs[0].properties) {
-      const sz = paragraph.runs[0].properties.numAttr('sz');
-      if (sz !== undefined) effectiveFontSize = sz / 100;
-    } else if (paragraph.runs.length === 0 && paragraph.endParaRPr) {
-      const sz = paragraph.endParaRPr.numAttr('sz');
-      if (sz !== undefined) effectiveFontSize = sz / 100;
+    const paragraphRunStyle = { ...defaultRunStyle };
+    const paragraphRunProperties = firstVisibleTextRun
+      ? firstVisibleTextRun.properties
+      : (paragraph.runs.find((run) => run.text === '\n' && run.properties)?.properties ??
+        paragraph.endParaRPr ??
+        paragraph.runs[0]?.properties);
+    if (paragraphRunProperties) {
+      mergeRunProps(paragraphRunStyle, paragraphRunProperties, ctx);
     }
+    const effectiveFontSize = paragraphRunStyle.fontSize ?? 12;
     // Browser line boxes include a "strut" based on the block element's own font size.
     // Keep the paragraph block in sync with Office's effective run size so tiny
     // multi-paragraph labels do not inherit a 13px page font and overflow their boxes.
     paraDiv.style.fontSize = `${effectiveFontSize * fontScale}pt`;
+    if (!firstVisibleTextRun) {
+      const paragraphFont = paragraphRunStyle.fontFamilyStack ?? paragraphRunStyle.fontFamily;
+      if (paragraphFont) paraDiv.style.fontFamily = cssFontFamilyStack(paragraphFont);
+    }
 
     const trimSpaceBefore =
       options?.trimOuterParagraphSpacing && paragraphIndex === firstVisibleParagraphIndex;
@@ -1010,7 +1016,6 @@ export function renderTextBody(
     // ---- Bullets ----
     // Suppress bullets for metadata placeholders (slide number, date, footer)
     // Also suppress for empty paragraphs (no visible runs) — PowerPoint never shows bullets for them
-    const hasVisibleRuns = paragraph.runs.some((r) => r.text != null && r.text.length > 0);
     const suppressBullet =
       !hasVisibleRuns ||
       placeholder?.type === 'sldNum' ||

--- a/src/shapes/presets.ts
+++ b/src/shapes/presets.ts
@@ -153,8 +153,8 @@ export const presetShapes: Map<string, PresetShapeGenerator> = new Map();
 presetShapes.set('rect', (w, h) => `M0,0 L${w},0 L${w},${h} L0,${h} Z`);
 
 presetShapes.set('roundRect', (w, h, adjustments) => {
-  const a = adj(adjustments, 'adj', 16667);
-  const r = Math.min(w, h) * a;
+  const a = Math.min(Math.max(adjRaw(adjustments, 'adj', 16667), 0), 50000);
+  const r = (Math.min(w, h) * a) / 100000;
   return [
     `M${r},0`,
     `L${w - r},0`,

--- a/test/browser/browser-package.spec.ts
+++ b/test/browser/browser-package.spec.ts
@@ -386,6 +386,195 @@ test('text overflow combinations remain non-scrollable in Chromium', async ({ pa
   }
 });
 
+test('browser layout preserves blank lines and roundRect wrapping', async ({ page }) => {
+  await page.goto('/test/browser/blank.html');
+  const result = await page.evaluate(async () => {
+    const [{ parseXml }, { parseShapeNode }, { renderShape }, { createMockRenderContext }] =
+      await Promise.all([
+        import('/src/parser/XmlParser.ts'),
+        import('/src/model/nodes/ShapeNode.ts'),
+        import('/src/renderer/ShapeRenderer.ts'),
+        import('/test/unit/helpers/mockContext.ts'),
+      ]);
+    const render = (xml: string) => {
+      const shape = renderShape(parseShapeNode(parseXml(xml)), createMockRenderContext());
+      document.body.appendChild(shape);
+      const container = Array.from(shape.querySelectorAll('div')).find(
+        (element) => element.style.flexDirection === 'column',
+      );
+      if (!container) throw new Error('Missing text container');
+      return { shape, container };
+    };
+
+    const blank = render(`
+      <p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:nvSpPr><p:cNvPr id="1" name="Blank lines"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="4762500" cy="4762500"/></a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr lIns="0" tIns="0" rIns="0" bIns="0"><a:noAutofit/></a:bodyPr>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:lnSpc><a:spcPct val="100000"/></a:lnSpc></a:pPr><a:r><a:rPr sz="1000"><a:latin typeface="Arial"/></a:rPr><a:t>Small </a:t></a:r><a:r><a:rPr sz="2000"><a:latin typeface="Arial"/></a:rPr><a:t>Before</a:t></a:r></a:p>
+          <a:p><a:pPr><a:lnSpc><a:spcPct val="100000"/></a:lnSpc></a:pPr><a:r><a:rPr sz="600"/><a:t/></a:r><a:endParaRPr sz="2000"><a:latin typeface="Arial"/></a:endParaRPr></a:p>
+          <a:p><a:pPr><a:lnSpc><a:spcPct val="100000"/></a:lnSpc></a:pPr><a:r><a:t/></a:r><a:endParaRPr sz="2000"><a:latin typeface="Arial"/></a:endParaRPr></a:p>
+          <a:p><a:pPr><a:lnSpc><a:spcPct val="100000"/></a:lnSpc></a:pPr><a:r><a:rPr sz="2000"><a:latin typeface="Arial"/></a:rPr><a:t>After</a:t></a:r></a:p>
+          <a:p><a:br/><a:endParaRPr sz="2000"><a:latin typeface="Arial"/></a:endParaRPr></a:p>
+        </p:txBody>
+      </p:sp>
+    `);
+    const paragraphRects = Array.from(blank.container.children).map((paragraph) => {
+      const rect = paragraph.getBoundingClientRect();
+      return {
+        height: rect.height,
+        top: rect.top,
+        fontFamily: getComputedStyle(paragraph).fontFamily,
+      };
+    });
+    blank.shape.remove();
+
+    const text = 'one two to in';
+    const probe = document.createElement('span');
+    probe.style.font = '20pt Arial';
+    probe.style.whiteSpace = 'pre';
+    probe.textContent = text;
+    document.body.appendChild(probe);
+    const fullTextWidth = probe.getBoundingClientRect().width;
+    probe.remove();
+    const height = 100;
+    const inset = height * (16667 / 100000) * 0.29289;
+    const width = fullTextWidth + inset;
+
+    const wordTops = (preset: 'rect' | 'roundRect') => {
+      const rendered = render(`
+        <p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:nvSpPr><p:cNvPr id="2" name="${preset}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+          <p:spPr>
+            <a:xfrm><a:off x="0" y="0"/><a:ext cx="${Math.ceil(width * 9525)}" cy="952500"/></a:xfrm>
+            <a:prstGeom prst="${preset}"><a:avLst/></a:prstGeom>
+          </p:spPr>
+          <p:txBody>
+            <a:bodyPr lIns="0" tIns="0" rIns="0" bIns="0" wrap="square"><a:noAutofit/></a:bodyPr>
+            <a:lstStyle/>
+            <a:p><a:r><a:rPr sz="2000"><a:latin typeface="Arial"/></a:rPr><a:t>${text}</a:t></a:r></a:p>
+          </p:txBody>
+        </p:sp>
+      `);
+      const textNode = rendered.container.querySelector('span')?.firstChild;
+      if (!textNode) throw new Error(`Missing ${preset} text`);
+      const top = (word: string) => {
+        const start = text.indexOf(word);
+        const range = document.createRange();
+        range.setStart(textNode, start);
+        range.setEnd(textNode, start + word.length);
+        return range.getBoundingClientRect().top;
+      };
+      const value = {
+        containerWidth: rendered.container.getBoundingClientRect().width,
+        inTop: top('in'),
+        toTop: top('to'),
+      };
+      rendered.shape.remove();
+      return value;
+    };
+
+    return {
+      blank: paragraphRects.slice(0, 4),
+      breakOnly: paragraphRects[4],
+      expectedRoundWidth: width - 2 * inset,
+      rect: wordTops('rect'),
+      roundRect: wordTops('roundRect'),
+    };
+  });
+
+  expect(result.blank).toHaveLength(4);
+  expect(result.blank.every(({ height }) => height > 0)).toBe(true);
+  const blankHeights = result.blank.map(({ height }) => height);
+  expect(Math.max(...blankHeights) - Math.min(...blankHeights)).toBeLessThanOrEqual(1);
+  for (let index = 1; index < result.blank.length; index += 1) {
+    expect(result.blank[index].top - result.blank[index - 1].top).toBeCloseTo(
+      result.blank[index - 1].height,
+      1,
+    );
+  }
+  expect(result.breakOnly.height).toBeGreaterThan(0);
+  expect(result.breakOnly.fontFamily).toContain('Arial');
+  expect(result.rect.inTop).toBeCloseTo(result.rect.toTop, 1);
+  expect(result.roundRect.inTop).toBeGreaterThan(result.roundRect.toTop);
+  expect(result.roundRect.containerWidth).toBeCloseTo(result.expectedRoundWidth, 1);
+});
+
+test('table paragraphs without lnSpc keep the existing cumulative fallback', async ({ page }) => {
+  await page.goto('/test/browser/blank.html');
+  const result = await page.evaluate(async () => {
+    const [{ renderTable }, { parseXml }, { createMockRenderContext }] = await Promise.all([
+      import('/src/renderer/TableRenderer.ts'),
+      import('/src/parser/XmlParser.ts'),
+      import('/test/unit/helpers/mockContext.ts'),
+    ]);
+    const run = (text: string) => ({
+      text,
+      properties: parseXml('<rPr sz="2000"><latin typeface="Arial"/></rPr>'),
+    });
+    const table = renderTable(
+      {
+        id: '1',
+        name: 'Cumulative paragraph spacing',
+        nodeType: 'table',
+        position: { x: 0, y: 0 },
+        size: { w: 400, h: 300 },
+        rotation: 0,
+        flipH: false,
+        flipV: false,
+        source: parseXml('<graphicFrame/>'),
+        columns: [400],
+        rows: [
+          {
+            height: 300,
+            cells: [
+              {
+                gridSpan: 1,
+                rowSpan: 1,
+                hMerge: false,
+                vMerge: false,
+                textBody: {
+                  paragraphs: [
+                    { runs: [run('First paragraph')], level: 0 },
+                    { runs: [run('NOTE'), { text: '\n' }, run('continued')], level: 0 },
+                    { runs: [run('WARNING')], level: 0 },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+      createMockRenderContext(),
+    );
+    document.body.replaceChildren(table);
+
+    return Array.from(table.querySelectorAll('td > div')).map((paragraph) => {
+      const rect = paragraph.getBoundingClientRect();
+      return {
+        fontSize: getComputedStyle(paragraph).fontSize,
+        height: rect.height,
+        lineHeight: getComputedStyle(paragraph).lineHeight,
+        top: rect.top,
+      };
+    });
+  });
+
+  const lineHeight = parseFloat(result[0].lineHeight);
+  expect(lineHeight).toBeCloseTo(parseFloat(result[0].fontSize), 1);
+  expect(result[1].height).toBeCloseTo(result[0].height * 2, 1);
+  expect(result[2].height).toBeCloseTo(result[0].height, 1);
+  expect(result[1].top - result[0].top).toBeCloseTo(result[0].height, 1);
+  expect(result[2].top - result[1].top).toBeCloseTo(result[1].height, 1);
+});
+
 test('embedded PPTX fonts load without host font installation', async ({ page }) => {
   await page.goto('/test/browser/blank.html');
   const result = await page.evaluate(async () => {

--- a/test/browser/browser-package.spec.ts
+++ b/test/browser/browser-package.spec.ts
@@ -435,6 +435,69 @@ test('browser layout preserves blank lines and roundRect wrapping', async ({ pag
     });
     blank.shape.remove();
 
+    const lineBreaks = render(`
+      <p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:nvSpPr><p:cNvPr id="3" name="Styled line breaks"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="4762500" cy="4762500"/></a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr lIns="0" tIns="0" rIns="0" bIns="0"><a:noAutofit/></a:bodyPr>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:lnSpc><a:spcPct val="100000"/></a:lnSpc></a:pPr><a:r><a:rPr sz="1000"><a:latin typeface="Arial"/></a:rPr><a:t>Before</a:t></a:r></a:p>
+          <a:p><a:pPr><a:lnSpc><a:spcPct val="100000"/></a:lnSpc></a:pPr><a:br><a:rPr sz="3000"><a:latin typeface="Arial"/></a:rPr></a:br><a:r><a:rPr sz="1000"><a:latin typeface="Arial"/></a:rPr><a:t>Styled</a:t></a:r></a:p>
+          <a:p><a:pPr><a:lnSpc><a:spcPct val="100000"/></a:lnSpc><a:defRPr sz="1800"><a:latin typeface="Courier New"/></a:defRPr></a:pPr><a:br/><a:r><a:rPr sz="1000"><a:latin typeface="Arial"/></a:rPr><a:t>Inherited</a:t></a:r></a:p>
+          <a:p><a:pPr><a:lnSpc><a:spcPct val="100000"/></a:lnSpc></a:pPr><a:r><a:rPr sz="1000"><a:latin typeface="Arial"/></a:rPr><a:t>After</a:t></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+    `);
+    const breakParagraphs = Array.from(lineBreaks.container.children) as HTMLElement[];
+    const breakMetrics = breakParagraphs.map((paragraph) => {
+      const rect = paragraph.getBoundingClientRect();
+      const breakElement = paragraph.querySelector('br')?.parentElement;
+      const textElement = Array.from(paragraph.querySelectorAll('span')).find(
+        (span) => span.textContent === 'Styled' || span.textContent === 'Inherited',
+      );
+      return {
+        height: rect.height,
+        top: rect.top,
+        paragraphFontSize: paragraph.style.fontSize,
+        paragraphFontFamily: paragraph.style.fontFamily,
+        breakTag: breakElement?.tagName,
+        breakFontSize: breakElement ? getComputedStyle(breakElement).fontSize : undefined,
+        breakFontFamily: breakElement ? getComputedStyle(breakElement).fontFamily : undefined,
+        textTop: textElement?.getBoundingClientRect().top,
+      };
+    });
+    lineBreaks.shape.remove();
+
+    const fixedLineSpacing = render(`
+      <p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:nvSpPr><p:cNvPr id="4" name="Fixed line spacing"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="4762500" cy="4762500"/></a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr lIns="0" tIns="0" rIns="0" bIns="0"><a:noAutofit/></a:bodyPr>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:lnSpc><a:spcPts val="2400"/></a:lnSpc></a:pPr><a:r><a:rPr sz="1000"/><a:t>First</a:t></a:r><a:br><a:rPr sz="3000"/></a:br><a:r><a:rPr sz="1000"/><a:t>Second</a:t></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+    `);
+    const fixedParagraph = fixedLineSpacing.container.firstElementChild as HTMLElement;
+    const fixedMetrics = {
+      wrapperCount: fixedParagraph.children.length,
+      wrapperHeights: Array.from(fixedParagraph.children).map(
+        (line) => line.getBoundingClientRect().height,
+      ),
+      brCount: fixedParagraph.querySelectorAll('br').length,
+    };
+    fixedLineSpacing.shape.remove();
+
     const text = 'one two to in';
     const probe = document.createElement('span');
     probe.style.font = '20pt Arial';
@@ -484,6 +547,8 @@ test('browser layout preserves blank lines and roundRect wrapping', async ({ pag
     return {
       blank: paragraphRects.slice(0, 4),
       breakOnly: paragraphRects[4],
+      breakMetrics,
+      fixedMetrics,
       expectedRoundWidth: width - 2 * inset,
       rect: wordTops('rect'),
       roundRect: wordTops('roundRect'),
@@ -502,6 +567,28 @@ test('browser layout preserves blank lines and roundRect wrapping', async ({ pag
   }
   expect(result.breakOnly.height).toBeGreaterThan(0);
   expect(result.breakOnly.fontFamily).toContain('Arial');
+  expect(result.breakMetrics).toHaveLength(4);
+  const [beforeBreak, styledBreak, inheritedBreak, afterBreak] = result.breakMetrics;
+  expect(styledBreak.paragraphFontSize).toBe('10pt');
+  expect(styledBreak.paragraphFontFamily).toBe('');
+  expect(styledBreak.breakTag).toBe('SPAN');
+  expect(parseFloat(styledBreak.breakFontSize!)).toBeCloseTo(40, 1);
+  expect(styledBreak.breakFontFamily).toContain('Arial');
+  expect(inheritedBreak.paragraphFontSize).toBe('10pt');
+  expect(inheritedBreak.paragraphFontFamily).toBe('');
+  expect(inheritedBreak.breakTag).toBe('SPAN');
+  expect(parseFloat(inheritedBreak.breakFontSize!)).toBeCloseTo(24, 1);
+  expect(inheritedBreak.breakFontFamily).toContain('Courier New');
+  expect(styledBreak.textTop! - styledBreak.top).toBeGreaterThan(
+    inheritedBreak.textTop! - inheritedBreak.top,
+  );
+  expect(styledBreak.height).toBeGreaterThan(inheritedBreak.height);
+  expect(styledBreak.top - beforeBreak.top).toBeCloseTo(beforeBreak.height, 1);
+  expect(inheritedBreak.top - styledBreak.top).toBeCloseTo(styledBreak.height, 1);
+  expect(afterBreak.top - inheritedBreak.top).toBeCloseTo(inheritedBreak.height, 1);
+  expect(result.fixedMetrics.wrapperCount).toBe(2);
+  expect(result.fixedMetrics.wrapperHeights).toEqual([32, 32]);
+  expect(result.fixedMetrics.brCount).toBe(0);
   expect(result.rect.inTop).toBeCloseTo(result.rect.toTop, 1);
   expect(result.roundRect.inTop).toBeGreaterThan(result.roundRect.toTop);
   expect(result.roundRect.containerWidth).toBeCloseTo(result.expectedRoundWidth, 1);

--- a/test/unit/parser/units.test.ts
+++ b/test/unit/parser/units.test.ts
@@ -4,6 +4,7 @@ import {
   emuToPt,
   angleToDeg,
   pctToDecimal,
+  parseOoxmlPercent,
   hundredthPtToPt,
   ptToPx,
   detectUnit,
@@ -59,6 +60,19 @@ describe('pctToDecimal', () => {
 
   it('converts 0 to 0', () => {
     expect(pctToDecimal(0)).toBe(0);
+  });
+});
+
+describe('parseOoxmlPercent', () => {
+  it.each([
+    ['120000', 1.2],
+    ['92.000%', 0.92],
+  ])('parses %s', (value, expected) => {
+    expect(parseOoxmlPercent(value)).toBe(expected);
+  });
+
+  it('rejects invalid values', () => {
+    expect(parseOoxmlPercent('not-a-percent')).toBeUndefined();
   });
 });
 

--- a/test/unit/renderer/ShapeRenderer.test.ts
+++ b/test/unit/renderer/ShapeRenderer.test.ts
@@ -2718,6 +2718,183 @@ describe('ShapeRenderer', () => {
     expect(paragraphs[1].style.marginBottom).toBe('0px');
   });
 
+  it('uses endParaRPr metrics only for empty paragraph struts', () => {
+    const xml = `
+      <p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:nvSpPr><p:cNvPr id="624" name="Slide 11 text"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="11273400" cy="4925400"/></a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+          <a:noFill/>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr anchor="t" wrap="square"><a:spAutoFit/></a:bodyPr>
+          <a:lstStyle/>
+          <a:p><a:r><a:rPr sz="2800"/><a:t>Visible paragraph before blanks</a:t></a:r></a:p>
+          <a:p>
+            <a:r><a:rPr sz="600"><a:latin typeface="Courier New"/></a:rPr><a:t/></a:r>
+            <a:endParaRPr sz="2800"><a:latin typeface="Arial"/></a:endParaRPr>
+          </a:p>
+          <a:p><a:r><a:t/></a:r><a:endParaRPr sz="2800"/></a:p>
+          <a:p>
+            <a:r><a:t/></a:r>
+            <a:r><a:rPr sz="2400"><a:latin typeface="Arial"/></a:rPr><a:t>Visible paragraph after blanks</a:t></a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+    `;
+
+    const el = renderShape(parseShapeNode(parseXml(xml)), createMockRenderContext());
+    const textContainer = Array.from(el.querySelectorAll('div')).find(
+      (div) =>
+        div.textContent?.includes('Visible paragraph after blanks') &&
+        div.style.flexDirection === 'column',
+    );
+    const paragraphs = Array.from(textContainer?.children ?? []) as HTMLElement[];
+
+    expect(paragraphs).toHaveLength(4);
+    expect(paragraphs.map((paragraph) => paragraph.style.fontSize)).toEqual([
+      '28pt',
+      '28pt',
+      '28pt',
+      '24pt',
+    ]);
+    expect(paragraphs[1].style.fontFamily).toBe('"Arial"');
+    expect(paragraphs[3].style.fontFamily).toBe('');
+    expect(paragraphs[1].querySelector('br')).not.toBeNull();
+    expect(paragraphs[2].querySelector('br')).not.toBeNull();
+  });
+
+  it('uses line-break properties before endParaRPr for break-only paragraph struts', () => {
+    const xml = `
+      <p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:nvSpPr><p:cNvPr id="625" name="Break-only lines"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="4762500" cy="4762500"/></a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr><a:noAutofit/></a:bodyPr>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Visible</a:t></a:r></a:p>
+          <a:p><a:br/><a:endParaRPr sz="2800"><a:latin typeface="Arial"/></a:endParaRPr></a:p>
+          <a:p><a:br><a:rPr sz="1800"><a:latin typeface="Courier New"/></a:rPr></a:br><a:endParaRPr sz="2800"><a:latin typeface="Arial"/></a:endParaRPr></a:p>
+        </p:txBody>
+      </p:sp>
+    `;
+
+    const el = renderShape(parseShapeNode(parseXml(xml)), createMockRenderContext());
+    const textContainer = Array.from(el.querySelectorAll('div')).find(
+      (div) => div.style.flexDirection === 'column',
+    );
+    const paragraphs = Array.from(textContainer?.children ?? []) as HTMLElement[];
+
+    expect(paragraphs[1].style.fontSize).toBe('28pt');
+    expect(paragraphs[1].style.fontFamily).toBe('"Arial"');
+    expect(paragraphs[2].style.fontSize).toBe('18pt');
+    expect(paragraphs[2].style.fontFamily).toBe('"Courier New"');
+  });
+
+  it('uses the roundRect inscribed text rectangle', () => {
+    const xml = `
+      <p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:nvSpPr><p:cNvPr id="725" name="Slide 16 text"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="653167" y="657300"/><a:ext cx="6317100" cy="1110000"/></a:xfrm>
+          <a:prstGeom prst="roundRect"><a:avLst><a:gd name="adj" fmla="val 16667"/></a:avLst></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr lIns="98425" rIns="98425" wrap="square"><a:noAutofit/></a:bodyPr>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr algn="l"><a:buNone/></a:pPr>
+            <a:r>
+              <a:rPr lang="en-US" sz="900"><a:latin typeface="Be Vietnam Pro"/></a:rPr>
+              <a:t>Rounded rectangle text uses the inscribed DrawingML bounds.</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+    `;
+
+    const node = parseShapeNode(parseXml(xml));
+    const el = renderShape(node, createMockRenderContext());
+    const textContainer = Array.from(el.querySelectorAll('div')).find(
+      (div) =>
+        div.textContent?.startsWith('Rounded rectangle') && div.style.flexDirection === 'column',
+    ) as HTMLElement | undefined;
+    const span = textContainer?.querySelector('span') as HTMLElement | null;
+    const expectedInset = Math.min(node.size.w, node.size.h) * (16667 / 100000) * (29289 / 100000);
+
+    expect(textContainer).toBeDefined();
+    expect(parseFloat(textContainer!.style.left)).toBeCloseTo(expectedInset, 5);
+    expect(parseFloat(textContainer!.style.top)).toBeCloseTo(expectedInset, 5);
+    expect(parseFloat(textContainer!.style.width)).toBeCloseTo(node.size.w - 2 * expectedInset, 5);
+    expect(parseFloat(textContainer!.style.height)).toBeCloseTo(node.size.h - 2 * expectedInset, 5);
+    expect(span!.style.letterSpacing).toBe('');
+
+    for (const [adjustment, expected] of [
+      [undefined, 16667],
+      [-10000, 0],
+      [75000, 50000],
+    ] as const) {
+      if (adjustment === undefined) node.adjustments.delete('adj');
+      else node.adjustments.set('adj', adjustment);
+      const adjusted = renderShape(node, createMockRenderContext());
+      const adjustedContainer = Array.from(adjusted.querySelectorAll('div')).find(
+        (div) =>
+          div.textContent?.startsWith('Rounded rectangle') && div.style.flexDirection === 'column',
+      ) as HTMLElement;
+      const adjustedInset = Math.min(node.size.w, node.size.h) * (expected / 100000) * 0.29289;
+      expect(parseFloat(adjustedContainer.style.left)).toBeCloseTo(adjustedInset, 5);
+    }
+  });
+
+  it('inherits explicit line spacing without changing visible paragraph font struts', () => {
+    const xml = `
+      <p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:nvSpPr><p:cNvPr id="1055" name="Slide 34 text"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="523500" y="1169000"/><a:ext cx="11449800" cy="5695200"/></a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr wrap="square"><a:spAutoFit/></a:bodyPr>
+          <a:lstStyle/>
+          <a:p><a:r><a:rPr sz="1600"/><a:t>Inherited percentage spacing</a:t></a:r></a:p>
+          <a:p><a:pPr><a:lnSpc><a:spcPts val="1800"/></a:lnSpc></a:pPr><a:r><a:rPr sz="1600"/><a:t>Explicit point spacing</a:t></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+    `;
+    const ctx = createMockRenderContext();
+    ctx.master.textStyles.otherStyle = parseXml(`
+      <p:otherStyle xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                    xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <a:lvl1pPr>
+          <a:lnSpc><a:spcPct val="100000"/></a:lnSpc>
+          <a:defRPr sz="1600"><a:latin typeface="Arial"/></a:defRPr>
+        </a:lvl1pPr>
+      </p:otherStyle>
+    `);
+
+    const el = renderShape(parseShapeNode(parseXml(xml)), ctx);
+    const textContainer = Array.from(el.querySelectorAll('div')).find(
+      (div) =>
+        div.textContent?.includes('Explicit point spacing') && div.style.flexDirection === 'column',
+    );
+    const paragraphs = Array.from(textContainer?.children ?? []) as HTMLElement[];
+
+    expect(paragraphs.map((paragraph) => paragraph.style.lineHeight)).toEqual(['1', '18pt']);
+    expect(paragraphs.map((paragraph) => paragraph.style.fontFamily)).toEqual(['', '']);
+    expect(
+      paragraphs.map((paragraph) => paragraph.querySelector('span')?.style.fontFamily),
+    ).toEqual(['"Arial"', '"Arial"']);
+  });
+
   it('renders supported prstTxWarp text as SVG textPath (ai-computing slide 28)', () => {
     const xml = `
       <p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
@@ -5501,8 +5678,8 @@ describe('ShapeRenderer', () => {
     expect(textContainer?.style.transform ?? '').not.toContain('scale(');
     expect(textContainer?.style.width).toBe('100%');
     expect(textContainer?.style.height).toBe('100%');
-    // Line spacing reduction should be applied
-    expect(textContainer?.style.lineHeight).toBeTruthy();
+    expect(textContainer?.style.lineHeight).toBe('');
+    expect((textContainer?.firstElementChild as HTMLElement).style.lineHeight).toBe('');
     // Text should be clipped at container boundary
     expect(textContainer?.style.overflowX).toBe('hidden');
     expect(textContainer?.style.overflowY).toBe('hidden');

--- a/test/unit/renderer/TableRenderer.test.ts
+++ b/test/unit/renderer/TableRenderer.test.ts
@@ -840,7 +840,7 @@ describe('renderTable', () => {
       expect(td.textContent).toContain('Cell Text');
     });
 
-    it('uses Office single line spacing for table cell text without explicit line spacing', () => {
+    it('keeps the existing table fallback without explicit line spacing', () => {
       const rows: TableRow[] = [
         {
           height: 0,
@@ -850,19 +850,29 @@ describe('renderTable', () => {
               rowSpan: 1,
               hMerge: false,
               vMerge: false,
-              textBody: { paragraphs: [{ runs: [{ text: 'Auto row height text' }], level: 0 }] },
+              textBody: {
+                paragraphs: [
+                  { runs: [{ text: 'First paragraph' }], level: 0 },
+                  {
+                    runs: [{ text: 'NOTE' }, { text: '\n' }, { text: 'continued' }],
+                    level: 0,
+                  },
+                  { runs: [{ text: 'WARNING' }], level: 0 },
+                ],
+              },
             },
           ],
         },
       ];
 
       const el = renderTable(makeTable({ columns: [400], rows }), makeCtx());
-      const paragraph = el.querySelector('td div') as HTMLElement;
+      const paragraphs = Array.from(el.querySelectorAll('td > div')) as HTMLElement[];
 
-      expect(paragraph.style.lineHeight).toBe('1');
+      expect(paragraphs.map((paragraph) => paragraph.style.lineHeight)).toEqual(['1', '1', '1']);
+      expect(paragraphs[1].querySelectorAll('br')).toHaveLength(1);
     });
 
-    it('preserves explicit table cell line spacing over the Office default', () => {
+    it('preserves explicit table cell line spacing over the fallback', () => {
       const rows: TableRow[] = [
         {
           height: 0,

--- a/test/unit/renderer/TextRenderer.lineSpacing.test.ts
+++ b/test/unit/renderer/TextRenderer.lineSpacing.test.ts
@@ -8,11 +8,13 @@ import type { TextBody } from '../../../src/model/nodes/ShapeNode';
 function makeTextBody(pPrXml?: string, bodyPrXml?: string): TextBody {
   return {
     bodyProperties: bodyPrXml ? xmlNode(bodyPrXml) : undefined,
-    paragraphs: [{
-      properties: pPrXml ? xmlNode(pPrXml) : undefined,
-      runs: [{ text: 'Hello' }],
-      level: 0,
-    }],
+    paragraphs: [
+      {
+        properties: pPrXml ? xmlNode(pPrXml) : undefined,
+        runs: [{ text: 'Hello' }],
+        level: 0,
+      },
+    ],
   };
 }
 
@@ -28,60 +30,65 @@ function renderAndGetPara(textBody: TextBody): HTMLElement {
 describe('TextRenderer — line spacing', () => {
   describe('lnSpc (line spacing)', () => {
     it('converts spcPct 100000 to unitless line-height 1.000', () => {
-      const body = makeTextBody(
-        `<pPr><lnSpc><spcPct val="100000"/></lnSpc></pPr>`,
-      );
+      const body = makeTextBody(`<pPr><lnSpc><spcPct val="100000"/></lnSpc></pPr>`);
       const para = renderAndGetPara(body);
       expect(parseFloat(para.style.lineHeight)).toBeCloseTo(1.0, 3);
     });
 
     it('converts spcPct 120000 to unitless line-height 1.2', () => {
-      const body = makeTextBody(
-        `<pPr><lnSpc><spcPct val="120000"/></lnSpc></pPr>`,
-      );
+      const body = makeTextBody(`<pPr><lnSpc><spcPct val="120000"/></lnSpc></pPr>`);
       const para = renderAndGetPara(body);
       expect(parseFloat(para.style.lineHeight)).toBeCloseTo(1.2, 3);
     });
 
     it('converts spcPct 150000 to unitless line-height 1.5', () => {
-      const body = makeTextBody(
-        `<pPr><lnSpc><spcPct val="150000"/></lnSpc></pPr>`,
-      );
+      const body = makeTextBody(`<pPr><lnSpc><spcPct val="150000"/></lnSpc></pPr>`);
       const para = renderAndGetPara(body);
       expect(parseFloat(para.style.lineHeight)).toBeCloseTo(1.5, 3);
     });
 
+    it('accepts percent-string line spacing', () => {
+      const para = renderAndGetPara(makeTextBody(`<pPr><lnSpc><spcPct val="120%"/></lnSpc></pPr>`));
+
+      expect(para.style.lineHeight).toBe('1.2');
+    });
+
     it('converts spcPts 1200 to 12pt line-height', () => {
-      const body = makeTextBody(
-        `<pPr><lnSpc><spcPts val="1200"/></lnSpc></pPr>`,
-      );
+      const body = makeTextBody(`<pPr><lnSpc><spcPts val="1200"/></lnSpc></pPr>`);
       const para = renderAndGetPara(body);
       expect(para.style.lineHeight).toBe('12pt');
     });
 
     it('converts spcPts 2000 to 20pt line-height', () => {
-      const body = makeTextBody(
-        `<pPr><lnSpc><spcPts val="2000"/></lnSpc></pPr>`,
-      );
+      const body = makeTextBody(`<pPr><lnSpc><spcPts val="2000"/></lnSpc></pPr>`);
       const para = renderAndGetPara(body);
       expect(para.style.lineHeight).toBe('20pt');
+    });
+
+    it('clears inherited absolute spacing when spcPct overrides spcPts', () => {
+      const body = makeTextBody(`<pPr><lnSpc><spcPct val="100000"/></lnSpc></pPr>`);
+      body.listStyle = xmlNode(
+        `<lstStyle><lvl1pPr><lnSpc><spcPts val="2000"/></lnSpc></lvl1pPr></lstStyle>`,
+      );
+      body.paragraphs[0].runs = [{ text: 'First' }, { text: '\n' }, { text: 'Second' }];
+
+      const para = renderAndGetPara(body);
+
+      expect(para.style.lineHeight).toBe('1');
+      expect(Array.from(para.children).filter((child) => child.tagName === 'DIV')).toHaveLength(0);
     });
   });
 
   describe('spcBef / spcAft (space before/after)', () => {
     it('applies spcBef in points as margin-top', () => {
-      const body = makeTextBody(
-        `<pPr><spcBef><spcPts val="600"/></spcBef></pPr>`,
-      );
+      const body = makeTextBody(`<pPr><spcBef><spcPts val="600"/></spcBef></pPr>`);
       const para = renderAndGetPara(body);
       // 600 / 100 = 6pt
       expect(para.style.marginTop).toBe('6pt');
     });
 
     it('applies spcAft in points as margin-bottom', () => {
-      const body = makeTextBody(
-        `<pPr><spcAft><spcPts val="400"/></spcAft></pPr>`,
-      );
+      const body = makeTextBody(`<pPr><spcAft><spcPts val="400"/></spcAft></pPr>`);
       const para = renderAndGetPara(body);
       // 400 / 100 = 4pt
       expect(para.style.marginBottom).toBe('4pt');
@@ -89,12 +96,21 @@ describe('TextRenderer — line spacing', () => {
 
     it('applies spcBef percentage-based spacing', () => {
       // spcPct val="50000" = 50% of font size
-      const body = makeTextBody(
-        `<pPr><spcBef><spcPct val="50000"/></spcBef></pPr>`,
-      );
+      const body = makeTextBody(`<pPr><spcBef><spcPct val="50000"/></spcBef></pPr>`);
       const para = renderAndGetPara(body);
       // 50% of default 12pt = 6pt → marginTop should be set
       expect(para.style.marginTop).not.toBe('');
+    });
+
+    it('accepts percent-string paragraph spacing', () => {
+      const para = renderAndGetPara(
+        makeTextBody(
+          `<pPr><spcBef><spcPct val="50%"/></spcBef><spcAft><spcPct val="25%"/></spcAft></pPr>`,
+        ),
+      );
+
+      expect(para.style.marginTop).toBe('6pt');
+      expect(para.style.marginBottom).toBe('3pt');
     });
   });
 
@@ -104,40 +120,58 @@ describe('TextRenderer — line spacing', () => {
       // Effective = 1.5 * (1 - 0.2) = 1.2
       const body: TextBody = {
         bodyProperties: xmlNode(`<bodyPr><normAutofit lnSpcReduction="20000"/></bodyPr>`),
-        paragraphs: [{
-          properties: xmlNode(`<pPr><lnSpc><spcPct val="150000"/></lnSpc></pPr>`),
-          runs: [{ text: 'Hello' }],
-          level: 0,
-        }],
+        paragraphs: [
+          {
+            properties: xmlNode(`<pPr><lnSpc><spcPct val="150000"/></lnSpc></pPr>`),
+            runs: [{ text: 'Hello' }],
+            level: 0,
+          },
+        ],
       };
       const para = renderAndGetPara(body);
       // 1.5 * 0.8 = 1.2
       expect(parseFloat(para.style.lineHeight)).toBeCloseTo(1.2, 3);
     });
 
-    it('reduces pt-based line spacing by normAutofit', () => {
-      // lnSpc=2000 (20pt), lnSpcReduction=25000 (25%)
-      // Effective = 20 * (1 - 0.25) = 15pt
+    it('accepts percent-string normAutofit values', () => {
+      const body = makeTextBody(
+        `<pPr><lnSpc><spcPct val="150%"/></lnSpc></pPr>`,
+        `<bodyPr><normAutofit fontScale="50%" lnSpcReduction="20%"/></bodyPr>`,
+      );
+      body.paragraphs[0].runs[0].properties = xmlNode('<rPr sz="2000"/>');
+
+      const para = renderAndGetPara(body);
+
+      expect(para.style.lineHeight).toBe('1.2');
+      expect(para.style.fontSize).toBe('10pt');
+      expect((para.firstElementChild as HTMLElement).style.fontSize).toBe('10pt');
+    });
+
+    it('does not reduce point-based line spacing by normAutofit', () => {
       const body: TextBody = {
         bodyProperties: xmlNode(`<bodyPr><normAutofit lnSpcReduction="25000"/></bodyPr>`),
-        paragraphs: [{
-          properties: xmlNode(`<pPr><lnSpc><spcPts val="2000"/></lnSpc></pPr>`),
-          runs: [{ text: 'Hello' }],
-          level: 0,
-        }],
+        paragraphs: [
+          {
+            properties: xmlNode(`<pPr><lnSpc><spcPts val="2000"/></lnSpc></pPr>`),
+            runs: [{ text: 'Hello' }],
+            level: 0,
+          },
+        ],
       };
       const para = renderAndGetPara(body);
-      expect(para.style.lineHeight).toMatch(/^15(\.0+)?pt$/);
+      expect(para.style.lineHeight).toBe('20pt');
     });
 
     it('does not reduce line spacing when lnSpcReduction is 0', () => {
       const body: TextBody = {
         bodyProperties: xmlNode(`<bodyPr><normAutofit lnSpcReduction="0"/></bodyPr>`),
-        paragraphs: [{
-          properties: xmlNode(`<pPr><lnSpc><spcPct val="120000"/></lnSpc></pPr>`),
-          runs: [{ text: 'Hello' }],
-          level: 0,
-        }],
+        paragraphs: [
+          {
+            properties: xmlNode(`<pPr><lnSpc><spcPct val="120000"/></lnSpc></pPr>`),
+            runs: [{ text: 'Hello' }],
+            level: 0,
+          },
+        ],
       };
       const para = renderAndGetPara(body);
       expect(parseFloat(para.style.lineHeight)).toBeCloseTo(1.2, 3);

--- a/test/unit/renderer/TextRenderer.test.ts
+++ b/test/unit/renderer/TextRenderer.test.ts
@@ -826,6 +826,34 @@ describe('TextRenderer — renderTextBody', () => {
       expect(bulletSpan!.style.color).toBe('rgb(255, 255, 255)');
     });
 
+    it('ignores leading break properties when resolving the first visible run color', () => {
+      const body = makeTextBody({
+        paragraphs: [
+          {
+            properties: xmlNode('<pPr><buChar char="•"/></pPr>'),
+            runs: [
+              {
+                text: '\n',
+                properties: xmlNode('<rPr><solidFill><srgbClr val="FF0000"/></solidFill></rPr>'),
+              },
+              {
+                text: 'Visible',
+                properties: xmlNode('<rPr><solidFill><srgbClr val="0000FF"/></solidFill></rPr>'),
+              },
+            ],
+            level: 0,
+          },
+        ],
+      });
+
+      const container = renderToContainer(body);
+      const bulletSpan = Array.from(container.querySelectorAll('span')).find((span) =>
+        span.textContent?.startsWith('•'),
+      );
+
+      expect(bulletSpan!.style.color).toBe('rgb(0, 0, 255)');
+    });
+
     it('suppresses bullet when buNone is present', () => {
       const body = makeTextBody({
         paragraphs: [

--- a/test/unit/shapes/presets.test.ts
+++ b/test/unit/shapes/presets.test.ts
@@ -24,6 +24,15 @@ describe('getPresetShapePath', () => {
     expect(d.length).toBeGreaterThan(0);
   });
 
+  it('clamps roundRect adjustments to the DrawingML range', () => {
+    expect(getPresetShapePath('roundRect', 200, 100, new Map([['adj', -1000]]))).toBe(
+      getPresetShapePath('roundRect', 200, 100, new Map([['adj', 0]])),
+    );
+    expect(getPresetShapePath('roundRect', 200, 100, new Map([['adj', 75000]]))).toBe(
+      getPresetShapePath('roundRect', 200, 100, new Map([['adj', 50000]])),
+    );
+  });
+
   it('returns an ellipse path', () => {
     const d = getPresetShapePath('ellipse', 100, 100);
     expect(d).toContain('A');


### PR DESCRIPTION
## Summary

- preserve consecutive blank paragraphs using effective `endParaRPr` metrics, including break-only paragraphs with `a:br/rPr`
- map DrawingML `spcPct` directly to unitless CSS line height (`val / 100000`)
- support both OOXML percentage encodings, such as `120000` and `120%`
- apply `normAutofit@lnSpcReduction` only to percentage line spacing; explicit point and implicit spacing remain unchanged
- keep visible paragraph font family on run spans instead of changing the parent block
- use the DrawingML inscribed text rectangle for `roundRect` and clamp its adjustment to the preset range
- keep the existing table fallback and cover cumulative browser layout without treating it as a new Office default

## Review follow-up

This update removes the shared `1.2` baseline and the shape-container line-height reduction. Percentage spacing now follows the DrawingML value directly, table fallback behavior is unchanged, and point spacing is not reduced by `lnSpcReduction`.

The branch was rebuilt as one commit on the current `main` so the diff contains only the behavior retained after review.

## Root cause

The previous branch mixed independent fixes with a global line-height policy. It also parsed percentage-valued attributes only as numbers, which ignored valid percent-string forms such as `20.000%`. Blank paragraphs containing only a line break could also skip their effective paragraph font metrics.

## Verification

- targeted Vitest renderer/parser suites: 1,024 tests passed
- targeted Playwright browser layout tests: 2 passed
- full Vitest run: 2,801 passed; one unrelated 50 ms timing guard measured 51.6 ms and passed on isolated rerun (11/11)
- `tsc --noEmit`
- ESLint on changed source files
- Prettier check on changed files
- `git diff --check`

## Compatibility / Risk

- no breaking API changes
- explicit point spacing, implicit shape spacing, table fallback, visible paragraph font-family behavior, and non-rounded text bounds remain unchanged
- changelog updated