### PR TITLE
fix(text): match placeholder by idx before falling back to type (#13)

### DIFF
--- a/src/renderer/TextRenderer.ts
+++ b/src/renderer/TextRenderer.ts
@@ -114,6 +114,7 @@ function findPlaceholderNode(
   placeholders: SafeXmlNode[],
   info: PlaceholderInfo,
 ): SafeXmlNode | undefined {
+  let typeMatch: SafeXmlNode | undefined;
   for (const ph of placeholders) {
     // Navigate to the ph element to read its attributes
     let phEl: SafeXmlNode | undefined;
@@ -132,11 +133,15 @@ function findPlaceholderNode(
     const phType = phEl.attr('type');
     const phIdx = phEl.numAttr('idx');
 
-    // Match by idx first (most specific), then by type
+    // Match by idx first (most specific): an exact idx match wins over any type-only match,
+    // even if a type match occurs on an earlier placeholder in the list.
     if (info.idx !== undefined && phIdx === info.idx) return ph;
-    if (info.type && phType === info.type) return ph;
+    // Remember the first type match as a fallback, used only if no idx match exists anywhere.
+    if (typeMatch === undefined && info.type && phType === info.type) {
+      typeMatch = ph;
+    }
   }
-  return undefined;
+  return typeMatch;
 }
 
 /**

--- a/test/unit/renderer/TextRenderer.placeholderInheritance.test.ts
+++ b/test/unit/renderer/TextRenderer.placeholderInheritance.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody } from '../../../src/renderer/TextRenderer';
+import { createMockRenderContext } from '../helpers/mockContext';
+import { xmlNode } from '../helpers/xmlNode';
+import type { PlaceholderEntry } from '../../../src/model/Layout';
+import type { TextBody } from '../../../src/model/nodes/ShapeNode';
+
+/**
+ * A layout placeholder shape carrying an optional level-1 `defRPr` solid colour in its `lstStyle`.
+ */
+function layoutPlaceholder(
+  type: string,
+  idx: number | null,
+  colourHex: string | null,
+): PlaceholderEntry {
+  const phAttrs = `type="${type}"${idx !== null ? ` idx="${idx}"` : ''}`;
+  const lstStyle =
+    colourHex !== null
+      ? `<lstStyle><lvl1pPr><defRPr><solidFill><srgbClr val="${colourHex}"/></solidFill></defRPr></lvl1pPr></lstStyle>`
+      : '';
+  return {
+    node: xmlNode(
+      `<sp><nvSpPr><nvPr><ph ${phAttrs}/></nvPr></nvSpPr><txBody>${lstStyle}</txBody></sp>`,
+    ),
+  };
+}
+
+function makeTextBody(): TextBody {
+  return {
+    bodyProperties: undefined,
+    listStyle: undefined,
+    paragraphs: [{ runs: [{ text: 'Hello' }], level: 0 }],
+  };
+}
+
+function renderColour(placeholders: PlaceholderEntry[], idx: number): string | undefined {
+  const ctx = createMockRenderContext();
+  ctx.layout.placeholders = placeholders;
+  const container = document.createElement('div');
+  renderTextBody(makeTextBody(), { type: 'title', idx }, ctx, container);
+  return container.querySelector('span')?.style.color;
+}
+
+describe('TextRenderer — placeholder colour inheritance (aiden0z/pptx-renderer#13)', () => {
+  it('matches the layout placeholder by idx, not the first same-type placeholder', () => {
+    // A deck (e.g. a Google Slides export) can have several placeholders of the same type with
+    // different idx. A title with no explicit run colour must inherit from the placeholder whose
+    // idx matches — not from the first one that merely shares its type.
+    const colour = renderColour(
+      [
+        layoutPlaceholder('title', null, 'FF0000'), // first type match, red — the trap
+        layoutPlaceholder('title', 3, '00FF00'), // idx match, green — the intended colour
+      ],
+      3,
+    );
+    expect(colour).toBe('rgb(0, 255, 0)');
+  });
+
+  it('falls back to a type match when no placeholder has the given idx', () => {
+    const colour = renderColour([layoutPlaceholder('title', null, 'FF0000')], 9);
+    expect(colour).toBe('rgb(255, 0, 0)');
+  });
+});


### PR DESCRIPTION
Fixes #13.

## Problem

`findPlaceholderNode` (in `src/renderer/TextRenderer.ts`) resolves the layout/master placeholder a slide placeholder inherits from. Its comment says *"Match by idx first (most specific), then by type"*, but the two checks run **inside the same iteration**:

```ts
for (const ph of placeholders) {
  // …
  if (info.idx !== undefined && phIdx === info.idx) return ph;
  if (info.type && phType === info.type) return ph;
}
```

So a **type** match on an *earlier* placeholder wins over an **idx** match on a *later* one. When a layout has several placeholders of the same type with different `idx` — common in Google Slides exports (e.g. two `title` placeholders, `idx=2` and `idx=3`) — a title with no explicit run colour matches the first same-type placeholder instead of the one with the matching `idx`. Its colour then falls back to the master's title style, e.g. rendering a **dark title on a dark background** instead of the layout's `lt1` white.

Reproduction (from #13): `ppt/slides/slide8.xml` has `title idx=2` and `title idx=3` (no explicit colour); `ppt/slideLayouts/slideLayout5.xml` defines `title` (no idx), `title idx=2` → accent1, `title idx=3` → `lt1`. The `idx=3` title rendered dark.

## Fix

Do a full pass over the placeholders: an exact **idx** match wins immediately; a **type**-only match is remembered as a fallback and returned only if no idx match exists anywhere.

```ts
let typeMatch: SafeXmlNode | undefined;
for (const ph of placeholders) {
  // …
  if (info.idx !== undefined && phIdx === info.idx) return ph;
  if (typeMatch === undefined && info.type && phType === info.type) typeMatch = ph;
}
return typeMatch;
```

Behaviour is unchanged except for the buggy case (idx match preceded by a type match), which now correctly resolves by idx.

## Tests

Added `test/unit/renderer/TextRenderer.placeholderInheritance.test.ts`:
- a `title idx=3` inherits the `idx=3` layout placeholder's colour (green), not the first same-type placeholder's (red) — **fails on `main`**, passes with the fix;
- with no matching idx, it still falls back to the type match.

`pnpm test` (100 TextRenderer tests), `pnpm lint`, `pnpm typecheck` all pass.