### PR TITLE
fix(chart): support literal series data and correct negative bar rendering

### DIFF
--- a/src/renderer/ChartRenderer.ts
+++ b/src/renderer/ChartRenderer.ts
@@ -716,7 +716,9 @@ function buildBarChartOption(
           ...(pointStyle.borderWidth !== undefined ? { borderWidth: pointStyle.borderWidth } : {}),
           ...(pointStyle.borderType ? { borderType: pointStyle.borderType } : {}),
         };
-      } else if (s.invertIfNegative !== false && rawValue < 0) {
+      } else if (s.invertIfNegative === true && rawValue < 0) {
+        // OOXML treats a missing c:invertIfNegative as off (PowerPoint renders
+        // the series color for negative points); only invert when explicitly on.
         itemStyle = { color: '#FFFFFF', borderColor: '#000000', borderWidth: 1 };
       } else if (varyColors && !s.colorHex && pointPalette.length > 0) {
         itemStyle = { color: pointPalette[pointIdx % pointPalette.length] };
@@ -2220,15 +2222,15 @@ export function applyZeroCrossingAxisLabelLayout(
     option.yAxis as MutableAxisOption | MutableAxisOption[],
   );
   const gridHeight = plotSpanPx(grid, chartSize.h, 'top', 'bottom');
-  const gridWidth = plotSpanPx(grid, chartSize.w, 'left', 'right');
   let applied = false;
 
   xAxes.forEach((xAxis, index) => {
     applied = applyCategoryLabelZeroOffset(xAxis, yAxes[index] ?? yAxes[0], gridHeight) || applied;
   });
-  yAxes.forEach((yAxis, index) => {
-    applied = applyCategoryLabelZeroOffset(yAxis, xAxes[index] ?? xAxes[0], gridWidth) || applied;
-  });
+  // Y category axes (horizontal bars) are deliberately skipped: ECharts keeps
+  // their labels anchored at the grid's left edge when the axis line moves to
+  // zero, so applying the zero offset there pushes labels into the plot over
+  // negative bars.
 
   if (applied && grid) {
     grid.containLabel = false;

--- a/src/renderer/chart/format.ts
+++ b/src/renderer/chart/format.ts
@@ -36,15 +36,29 @@ function isCachePointInRange(idx: number | undefined, pointLimit: number): idx i
   );
 }
 
+// Chart data points live in a cache under a reference (strRef/strCache,
+// numRef/numCache), in literal data (strLit/numLit, used by generators that
+// embed values directly instead of a workbook), or in a bare cache element.
+// Return the first container that exists; a dangling reference without its
+// cache falls through so callers can try the next data kind.
+function selectDataContainer(
+  refNode: SafeXmlNode,
+  refName: 'strRef' | 'numRef',
+  litName: 'strLit' | 'numLit',
+  cacheName: 'strCache' | 'numCache',
+): SafeXmlNode {
+  const ref = refNode.child(refName);
+  if (ref.exists()) return ref.child(cacheName);
+  const lit = refNode.child(litName);
+  if (lit.exists()) return lit;
+  return refNode.child(cacheName);
+}
+
 export function extractStringValues(refNode: SafeXmlNode): string[] {
-  const cache = refNode.child('strRef').exists()
-    ? refNode.child('strRef').child('strCache')
-    : refNode.child('strCache');
+  const cache = selectDataContainer(refNode, 'strRef', 'strLit', 'strCache');
 
   if (!cache.exists()) {
-    const numCache = refNode.child('numRef').exists()
-      ? refNode.child('numRef').child('numCache')
-      : refNode.child('numCache');
+    const numCache = selectDataContainer(refNode, 'numRef', 'numLit', 'numCache');
     if (numCache.exists()) {
       return extractNumericValuesAsStrings(numCache);
     }
@@ -66,9 +80,7 @@ export function extractStringValues(refNode: SafeXmlNode): string[] {
 }
 
 export function extractFormatCode(refNode: SafeXmlNode): string | undefined {
-  const cache = refNode.child('numRef').exists()
-    ? refNode.child('numRef').child('numCache')
-    : refNode.child('numCache');
+  const cache = selectDataContainer(refNode, 'numRef', 'numLit', 'numCache');
 
   if (!cache.exists()) return undefined;
 
@@ -198,9 +210,7 @@ interface NumericValuesWithBlanks {
 }
 
 export function extractNumericValuesWithBlanks(refNode: SafeXmlNode): NumericValuesWithBlanks {
-  const cache = refNode.child('numRef').exists()
-    ? refNode.child('numRef').child('numCache')
-    : refNode.child('numCache');
+  const cache = selectDataContainer(refNode, 'numRef', 'numLit', 'numCache');
 
   if (!cache.exists()) return { values: [], blankIndices: new Set() };
 

--- a/test/unit/renderer/ChartRenderer.test.ts
+++ b/test/unit/renderer/ChartRenderer.test.ts
@@ -6086,7 +6086,7 @@ describe('ChartRenderer', () => {
       expect(grid.right).not.toBe(10);
     });
 
-    it('varies single-series bar colors by point and inverts negative values by default (oracle-pypptx-chart-0002)', () => {
+    it('varies single-series bar colors by point without inverting negative values by default (oracle-pypptx-chart-0002)', () => {
       const xml = `<c:chartSpace
         xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
         xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
@@ -6119,7 +6119,7 @@ describe('ChartRenderer', () => {
       });
       expect(series.data[1]).toMatchObject({
         value: -8,
-        itemStyle: { color: '#FFFFFF', borderColor: '#000000', borderWidth: 1 },
+        itemStyle: { color: '#d16e2b' },
       });
       expect(series.data[2]).toMatchObject({
         value: 22,
@@ -6272,6 +6272,27 @@ describe('ChartRenderer', () => {
       expect(option.xAxis.z).toBeGreaterThan(10);
       expect(option.grid.containLabel).toBe(false);
       expect(option.grid.left).toBeGreaterThanOrEqual(48);
+    });
+
+    it('leaves y-axis category labels at the grid edge for zero-crossing horizontal bars', () => {
+      const option: any = {
+        grid: { left: 40, right: 20 },
+        xAxis: { type: 'value', min: -10, max: 30 },
+        yAxis: {
+          type: 'category',
+          axisLine: { onZero: true },
+          axisLabel: { fontSize: 10 },
+        },
+        series: [{ type: 'bar', data: [-5, 10] }],
+      };
+
+      applyZeroCrossingAxisLabelLayout(option, { w: 400, h: 300 });
+
+      // ECharts already anchors y-axis category labels at the grid's outer
+      // bounds when the axis line moves to zero; shifting them again by the
+      // zero offset pushes the labels into the plot over negative bars.
+      expect(option.yAxis.axisLabel.margin).toBeUndefined();
+      expect(option.grid.containLabel).not.toBe(false);
     });
 
     it('keeps dense line chart category labels horizontal unless OOXML requests rotation (oracle-pypptx-chart-0021)', () => {
@@ -7249,7 +7270,7 @@ describe('ChartRenderer', () => {
       expect((option.yAxis as any).axisLabel.formatter(0.25)).toBe('25%');
     });
 
-    it('applies default negative bar inversion but honors invertIfNegative=false', () => {
+    it('renders bar series from literal strLit/numLit chart data', () => {
       const xml = `
         <c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
                       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
@@ -7260,14 +7281,56 @@ describe('ChartRenderer', () => {
                 <c:grouping val="clustered"/>
                 <c:ser>
                   <c:idx val="0"/><c:order val="0"/>
-                  <c:tx><c:v>Default invert</c:v></c:tx>
+                  <c:tx><c:v>Literal data</c:v></c:tx>
+                  <c:cat><c:strLit><c:ptCount val="2"/><c:pt idx="0"><c:v>A</c:v></c:pt><c:pt idx="1"><c:v>B</c:v></c:pt></c:strLit></c:cat>
+                  <c:val><c:numLit><c:ptCount val="2"/><c:pt idx="0"><c:v>-0.84</c:v></c:pt><c:pt idx="1"><c:v>2.81</c:v></c:pt></c:numLit></c:val>
+                </c:ser>
+                <c:axId val="1"/><c:axId val="2"/>
+              </c:barChart>
+              <c:catAx><c:axId val="1"/><c:crossAx val="2"/></c:catAx>
+              <c:valAx><c:axId val="2"/><c:crossAx val="1"/></c:valAx>
+            </c:plotArea>
+          </c:chart>
+        </c:chartSpace>`;
+
+      const { option } = parseChartOption(xml);
+      const series = option.series as any[];
+
+      const values = series[0].data.map((d: unknown) =>
+        typeof d === 'object' && d !== null && 'value' in d
+          ? (d as { value: number }).value
+          : d,
+      );
+      expect(values).toEqual([-0.84, 2.81]);
+      expect((option.yAxis as any).data).toEqual(['A', 'B']);
+    });
+
+    it('inverts negative bar colors only when invertIfNegative is explicitly enabled', () => {
+      const xml = `
+        <c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                      xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <c:chart>
+            <c:plotArea>
+              <c:barChart>
+                <c:barDir val="bar"/>
+                <c:grouping val="clustered"/>
+                <c:ser>
+                  <c:idx val="0"/><c:order val="0"/>
+                  <c:tx><c:v>Default</c:v></c:tx>
                   <c:cat><c:strRef><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>A</c:v></c:pt></c:strCache></c:strRef></c:cat>
                   <c:val><c:numRef><c:numCache><c:ptCount val="1"/><c:pt idx="0"><c:v>-5</c:v></c:pt></c:numCache></c:numRef></c:val>
                 </c:ser>
                 <c:ser>
                   <c:idx val="1"/><c:order val="1"/>
-                  <c:tx><c:v>No invert</c:v></c:tx>
+                  <c:tx><c:v>Explicit off</c:v></c:tx>
                   <c:invertIfNegative val="0"/>
+                  <c:cat><c:strRef><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>A</c:v></c:pt></c:strCache></c:strRef></c:cat>
+                  <c:val><c:numRef><c:numCache><c:ptCount val="1"/><c:pt idx="0"><c:v>-5</c:v></c:pt></c:numCache></c:numRef></c:val>
+                </c:ser>
+                <c:ser>
+                  <c:idx val="2"/><c:order val="2"/>
+                  <c:tx><c:v>Explicit on</c:v></c:tx>
+                  <c:invertIfNegative val="1"/>
                   <c:cat><c:strRef><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>A</c:v></c:pt></c:strCache></c:strRef></c:cat>
                   <c:val><c:numRef><c:numCache><c:ptCount val="1"/><c:pt idx="0"><c:v>-5</c:v></c:pt></c:numCache></c:numRef></c:val>
                 </c:ser>
@@ -7282,12 +7345,15 @@ describe('ChartRenderer', () => {
       const { option } = parseChartOption(xml);
       const series = option.series as any[];
 
-      expect(series[0].data[0].itemStyle).toMatchObject({
+      // PowerPoint leaves the series color untouched when the element is
+      // absent or explicitly off.
+      expect(series[0].data[0]).toBe(-5);
+      expect(series[1].data[0]).toBe(-5);
+      expect(series[2].data[0].itemStyle).toMatchObject({
         color: '#FFFFFF',
         borderColor: '#000000',
         borderWidth: 1,
       });
-      expect(series[1].data[0]).toBe(-5);
       expect((option.yAxis as any).type).toBe('category');
     });
 

--- a/test/unit/renderer/chart/format.test.ts
+++ b/test/unit/renderer/chart/format.test.ts
@@ -61,6 +61,51 @@ describe('chart format helpers', () => {
     expect(formatValue(0.125, extractFormatCode(node))).toBe('12.5%');
   });
 
+  it('reads string values from strLit literal data when no cache exists', () => {
+    const node = parseXml(`
+      <c:cat xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:strLit>
+          <c:ptCount val="3"/>
+          <c:pt idx="0"><c:v>Alpha</c:v></c:pt>
+          <c:pt idx="2"><c:v>Gamma</c:v></c:pt>
+        </c:strLit>
+      </c:cat>
+    `);
+
+    expect(extractStringValues(node)).toEqual(['Alpha', '', 'Gamma']);
+  });
+
+  it('reads numeric literal data and format codes from numLit', () => {
+    const node = parseXml(`
+      <c:val xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:numLit>
+          <c:formatCode>0.0%</c:formatCode>
+          <c:ptCount val="2"/>
+          <c:pt idx="0"><c:v>0.125</c:v></c:pt>
+          <c:pt idx="1"><c:v>0.5</c:v></c:pt>
+        </c:numLit>
+      </c:val>
+    `);
+
+    expect(extractFormatCode(node)).toBe('0.0%');
+    expect(extractNumericValues(node)).toEqual([0.125, 0.5]);
+  });
+
+  it('falls back to numeric literal data as category strings and formats date serials', () => {
+    const node = parseXml(`
+      <c:cat xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:numLit>
+          <c:formatCode>m/d/yyyy</c:formatCode>
+          <c:ptCount val="2"/>
+          <c:pt idx="0"><c:v>61</c:v></c:pt>
+          <c:pt idx="1"><c:v>62</c:v></c:pt>
+        </c:numLit>
+      </c:cat>
+    `);
+
+    expect(extractStringValues(node)).toEqual(['1900/3/1', '1900/3/2']);
+  });
+
   it('uses stable UTC Excel serial conversion', () => {
     expect(excelSerialToDateString(59)).toBe('1900/2/28');
     expect(excelSerialToDateString(61)).toBe('1900/3/1');


### PR DESCRIPTION
## What

Three chart rendering fixes, all hit by the same real-world deck (a programmatically generated PPTX whose charts embed literal data):

1. **Read `strLit`/`numLit` literal series data.** The chart parsers only looked at `strRef/strCache` and `numRef/numCache`. Generators that embed values directly as literal data (`c:strLit` / `c:numLit`) instead of referencing a workbook produced series with empty value arrays — the chart rendered axes and gridlines but no bars/lines/points at all. A new `selectDataContainer` helper in `src/renderer/chart/format.ts` now resolves reference cache → literal → bare cache, and `extractFormatCode` reads `formatCode` from `numLit` too.
2. **Only invert negative bar colors when `c:invertIfNegative` is explicitly enabled.** The previous condition `invertIfNegative !== false` treated a *missing* element as opt-in, turning every negative bar into a white fill with a black border. PowerPoint leaves the series color untouched when the element is absent (the "Invert if negative" checkbox is off by default), and python-pptx always writes `<c:invertIfNegative val="0"/>` explicitly. This is now `=== true`.
3. **Skip the zero-crossing category label offset for y axes.** `applyZeroCrossingAxisLabelLayout` was designed for x category axes (covered by the existing `margin = -92` test). Applying it to y category axes (horizontal bars) double-compensated: ECharts already anchors those labels at the grid's left edge when the axis line moves to zero, and the extra negative margin pushed the labels into the plot, overlapping negative bars and their data labels. The y-axis loop is removed with a comment explaining why.

## Evidence                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                           
The deck that surfaced this: a programmatically generated weekly-report PPTX whose                                                                                                                                                                                                                                                    
6 charts all store series data as `c:strLit`/`c:numLit` (no workbook caches).                                                                                                                                                                                                                                                         
Rendered with `test/pages/render-slide.html` (main vs this branch): 



| Slide | main | this branch |                                                                                                                                                                                                                                                                                                        
| --- | --- | --- |                                                                                                                                                                                                                                                                                                                   
| horizontal bar, crosses zero | ![before](https://github.com/user-attachments/assets/ac434ec0-f67e-4183-81fa-9ab2e3cb863f) | ![after](https://github.com/user-attachments/assets/b87175b1-8640-479f-9d5a-6390feb6451f) |                                                                                                                                                                                                                                                
| bar+line combo | ![before](https://github.com/user-attachments/assets/612fb290-7c19-453a-b9bc-5a7794c3a08e) | ![after](https://github.com/user-attachments/assets/bb8960f4-b027-46b5-adb9-085f97817f4e) |                                                                                                                                                                                                                                                              
| cross-asset bar, negative value | ![before](https://github.com/user-attachments/assets/27d3099d-58a5-4492-81a1-4dbf9c5febce) | ![after](https://github.com/user-attachments/assets/f18d7264-3b31-4972-8561-c31aab540fef) |                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                      
On main every chart shows axes and gridlines but zero series. On this branch all                                                                                                                                                                                                                                                      
series render; the negative bar keeps the series color and the y-axis category                                                                                                                                                                                                                                                        
labels stay at the grid edge instead of overlapping the bar.


## Tests

- New unit tests: `strLit`/`numLit` extraction (values, format codes, date-serial categories), a renderer-level literal bar chart assertion, explicit on/off/absent `invertIfNegative` matrix, and a y-axis zero-crossing guard.
- Updated: the `oracle-pypptx-chart-0002` unit test now asserts PowerPoint-consistent negative point coloring.
- `pnpm test` — 87 files / 2795 tests pass; `pnpm lint`, `pnpm format:check`, `pnpm typecheck` clean.
- Not run locally: the oracle visual eval (requires the E2E testdata/PDF pipeline). Fix 2 is behavior-identical for python-pptx cases as noted above; fix 3 only affects horizontal bar charts crossing zero.

## Out of scope

- Evaluating `c:f` formulas against the embedded workbook when neither cache nor literal data is present.
- Parsing an inverted fill override for `invertIfNegative=1` (the hardcoded white/black placeholder is kept).
