### PR TITLE
fix: render Office SVG picture relationships

### DIFF
--- a/src/model/nodes/PicNode.ts
+++ b/src/model/nodes/PicNode.ts
@@ -43,8 +43,18 @@ export function parsePicNode(picNode: SafeXmlNode): PicNodeData {
   const blipFill = picNode.child('blipFill');
   const blip = blipFill.child('blip');
 
-  // Try both namespaced and non-namespaced embed attribute
-  const blipEmbed = blip.attr('embed') ?? blip.attr('r:embed');
+  // PowerPoint stores SVG pictures in an Office extension relationship on the
+  // blip, with the raster relationship (when present) acting as a fallback.
+  // Prefer the SVG relationship so SVG-only pictures are not treated as
+  // missing images and SVG-with-PNG-fallback pictures retain their fidelity.
+  const svgBlip = blip
+    .child('extLst')
+    .children('ext')
+    .map((ext) => ext.child('svgBlip'))
+    .find((candidate) => candidate.exists());
+  const svgEmbed = svgBlip?.attr('embed') ?? svgBlip?.attr('r:embed');
+  const rasterEmbed = blip.attr('embed') ?? blip.attr('r:embed');
+  const blipEmbed = svgEmbed ?? rasterEmbed;
   const blipLink = blip.attr('link') ?? blip.attr('r:link');
 
   // --- Crop (srcRect) ---

--- a/test/unit/model/nodes/PicNode.test.ts
+++ b/test/unit/model/nodes/PicNode.test.ts
@@ -6,6 +6,7 @@ function makePicXml(
   opts: {
     embed?: string;
     link?: string;
+    svgEmbed?: string;
     srcRect?: { t?: number; b?: number; l?: number; r?: number };
     video?: boolean;
     audio?: boolean;
@@ -20,6 +21,9 @@ function makePicXml(
   const blipAttrs = [embed ? `embed="${embed}"` : '', opts.link ? `link="${opts.link}"` : '']
     .filter(Boolean)
     .join(' ');
+  const svgBlip = opts.svgEmbed
+    ? `<extLst><ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}"><asvg:svgBlip r:embed="${opts.svgEmbed}"/></ext></extLst>`
+    : '';
   const srcRect = opts.srcRect
     ? `<srcRect ${Object.entries(opts.srcRect)
         .map(([k, v]) => `${k}="${v}"`)
@@ -58,13 +62,14 @@ function makePicXml(
 
   return parseXml(`
     <pic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
-         xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+         xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+         xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main">
       <nvPicPr>
         <cNvPr id="5" name="Picture 1"/>
         <nvPr>${media}</nvPr>
       </nvPicPr>
       <blipFill>
-        <blip ${blipAttrs}/>
+        <blip ${blipAttrs}>${svgBlip}</blip>
         ${srcRect}
       </blipFill>
       <spPr>
@@ -115,6 +120,20 @@ describe('parsePicNode', () => {
     );
 
     expect(node.blipEmbed).toBe('rIdAlt');
+  });
+
+  it('prefers the Office SVG relationship over the raster fallback', () => {
+    const node = parsePicNode(
+      makePicXml({ embed: 'rIdPng', svgEmbed: 'rIdSvg' }),
+    );
+
+    expect(node.blipEmbed).toBe('rIdSvg');
+  });
+
+  it('uses an Office SVG relationship when the raster relationship is absent', () => {
+    const node = parsePicNode(makePicXml({ embed: '', svgEmbed: 'rIdSvg' }));
+
+    expect(node.blipEmbed).toBe('rIdSvg');
   });
 
   it('parses crop rect', () => {


### PR DESCRIPTION
Fixes #16

## Summary

- Prefer the Office `svgBlip` relationship when parsing picture nodes.
- Preserve the existing raster `a:blip` relationship as a fallback when no SVG relationship is present.
- Add regression coverage for SVG-only pictures and SVG pictures with a raster fallback.

The issue attachment was also rendered directly in Chromium: all three pictures loaded successfully after this change.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm build`
- `pnpm test:browser`